### PR TITLE
Single iterrable output

### DIFF
--- a/pyungo/core.py
+++ b/pyungo/core.py
@@ -175,12 +175,9 @@ class Graph:
                 for kwarg in node.kwargs:
                     kwargs_to_pass[kwarg] = self._data[kwarg]
                 res = node(data_to_pass, **kwargs_to_pass)
-                try:
-                    iter(res)
-                except TypeError:
-                    res = [res]
-                for i, out in enumerate(node.output_names):
-                    self._data[out] = res[i]
-        if len(res) == 1:
-            return res[0]
+                if len(node.output_names) == 1:
+                    self._data[node.output_names[0]] = res
+                else:
+                    for i, out in enumerate(node.output_names):
+                        self._data[out] = res[i]
         return res

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,6 +20,7 @@ def test_simple():
     res = graph.calculate(data={'a': 2, 'b': 3})
 
     assert res == -1.5
+    assert graph.data['e'] == -1.5
 
 
 def test_simple_without_decorator():
@@ -41,6 +42,7 @@ def test_simple_without_decorator():
     res = graph.calculate(data={'a': 2, 'b': 3})
 
     assert res == -1.5
+    assert graph.data['e'] == -1.5
 
 
 def test_multiple_outputs():
@@ -57,6 +59,7 @@ def test_multiple_outputs():
     res = graph.calculate(data={'a': 2, 'b': 3})
 
     assert res == 11
+    assert graph.data['e'] == 11
 
 
 def test_same_output_names():
@@ -140,6 +143,7 @@ def test_iterable_on_single_output():
     res = graph.calculate(data={'a': 2, 'b': 3})
 
     assert res == [0, 1, 3]
+    assert graph.data['c'] == [0, 1, 3]
 
 
 def test_multiple_outputs_with_iterable():
@@ -173,6 +177,7 @@ def test_args_kwargs():
     res = graph.calculate(data={'a': 2, 'b': 3, 'c': 4, 'd': 5})
 
     assert res == 14
+    assert graph.data['e'] == 14
 
 
 def test_dag_pretty_print():


### PR DESCRIPTION
Fix #4. See also #5 for reference.

Tests were mostly focus on output returned by `calculate`, so enforcing them to check the registered output as well. 