### PR TITLE
v0.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            #pip install -r requirements.txt
+            pip install multiprocess
 
       # run tests!
       # this example uses Django's built-in test-runner

--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,13 @@ parallelism
 When resolving the dag, pyungo figure out nodes that can be run
 in parallel. When creating a graph, we can specify the option
 `parallel=True` for running calculations concurently when possible,
-using `Python multiprocessing module <https://docs.python.org/3.6/library/multiprocessing.html>`_.
-We can specify the pool size when instantiating the Graph. This will
-set the maximum number of processes that will be launched. If 3 nodes
-can run in parallel and just 2 processes are used, pyungo will run
-calculation on the first 2 nodes first and will run the last one as soon
-as a process will be free.
+using `multiprocess module <https://pypi.org/project/multiprocess/>`_.
+This package is not automatically installed with pyungo, and will need
+to be installed manually if parallelism is used.  We can specify the
+pool size when instantiating the Graph. This will set the maximum number
+of processes that will be launched. If 3 nodes can run in parallel and 
+just 2 processes are used, pyungo will run calculation on the first 2 nodes
+first and will run the last one as soon as a process will be free.
 
 Instantiating a `Graph` with a pool of 5 processes for running calculations
 in parralel:

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,33 @@ in the ``graph`` instance.
 
 The result will be (a + b) / 10 - a = -1.5
 
+parallelism
+-----------
+
+When resolving the dag, pyungo figure out nodes that can be run
+in parallel. When creating a graph, we can specify the option
+`parallel=True` for running calculations concurently when possible,
+using `Python multiprocessing module <https://docs.python.org/3.6/library/multiprocessing.html>`_.
+We can specify the pool size when instantiating the Graph. This will
+set the maximum number of processes that will be launched. If 3 nodes
+can run in parallel and just 2 processes are used, pyungo will run
+calculation on the first 2 nodes first and will run the last one as soon
+as a process will be free.
+
+Instantiating a `Graph` with a pool of 5 processes for running calculations
+in parralel:
+
+.. code-block:: python
+
+    graph = Graph(parallel=True, pool_size=5)
+
+
+Note: Running functions in parallel has a cost. Python will spend time
+creating / deleting new processes. Parallelism is recommended when at
+least 2 concurrent nodes have heavy calculations which takes a significant
+amount of time.
+
+
 sanity check
 ------------
 

--- a/pyungo/core.py
+++ b/pyungo/core.py
@@ -2,12 +2,18 @@ from copy import deepcopy
 import datetime as dt
 from functools import reduce
 import logging
-from multiprocessing.dummy import Pool as ThreadPool
 
 
 logging.basicConfig()
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
+
+
+try:
+    from multiprocess import Pool
+except ImportError:
+    msg = 'multiprocess is not installed and needed for parralelism'
+    LOGGER.warning(msg)
 
 
 class PyungoError(Exception):
@@ -93,6 +99,12 @@ class Graph:
         self._data = None
         self._parallel = parallel
         self._pool_size = pool_size
+        if parallel:
+            try:
+                import multiprocess
+            except ImportError:
+                msg = 'multiprocess package is needed for parralelism'
+                raise ImportError(msg)
 
     @property
     def data(self):
@@ -209,7 +221,7 @@ class Graph:
                 node.load_inputs(data_to_pass, kwargs_to_pass)
             # running nodes
             if self._parallel:
-                pool = ThreadPool(self._pool_size)
+                pool = Pool(self._pool_size)
                 results = pool.map(
                     Graph.run_node,
                     [self._get_node(i) for i in items]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(HERE, 'README.rst')) as f:
 
 setup(
     name='pyungo',
-    version='0.5.0',
+    version='0.5.1',
     description='Function dependencies resolution and execution',
     long_description=README,
     url='https://github.com/cedricleroy/pyungo',


### PR DESCRIPTION
Use `multiprocess` library for parallelism. Previous version was using `multiprocessing.dumy` which is just an thread API useful for IO things, not for processing. 
The standard Python `multiprocessing` library cannot Pickle (~serialize) objects easily, while `multiprocess` (a fork of `multiprocessing`) can. It is an optional import for now, maybe a pure Python version would be worth to investigate someday.