### PR TITLE
predefined inputs

### DIFF
--- a/pyungo/core.py
+++ b/pyungo/core.py
@@ -40,11 +40,12 @@ def topological_sort(data):
 
 class Node:
     ID = 0
-    def __init__(self, fct, input_names, output_names, args=None, kwargs=None):
+    def __init__(self, fct, inputs, output_names, args=None, kwargs=None):
         Node.ID += 1
         self._id = str(Node.ID)
         self._fct = fct
-        self._input_names = input_names
+        self._data_provided = {}
+        self._process_inputs(inputs)
         self._args = args if args else []
         self._kwargs = kwargs if kwargs else []
         self._output_names = output_names
@@ -85,9 +86,24 @@ class Node:
     def fct_name(self):
         return self._fct.__name__
 
+    def _process_inputs(self, inputs):
+        self._input_names = []
+        for input_ in inputs:
+            if isinstance(input_, str):
+                self._input_names.append(input_)
+            elif isinstance(input_, dict):
+                if len(input_) != 1:
+                    msg = 'dict inputs should have only one key and cannot be empty'
+                    raise PyungoError(msg)
+                self._data_provided.update(input_)
+            else:
+                msg = 'inputs need to be of type str or dict'
+                raise PyungoError(msg)
+
     def load_inputs(self, data_to_pass, kwargs_to_pass):
         self._data_to_pass = data_to_pass
         self._kwargs_to_pass = kwargs_to_pass 
+        self._kwargs_to_pass.update(self._data_provided)
 
     def run_with_loaded_inputs(self):
         return self(self._data_to_pass, **self._kwargs_to_pass)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -240,3 +240,51 @@ def test_missing_inputs():
     with pytest.raises(PyungoError) as err:
         graph.add_node(f_my_function, inputs=['a', 'b'])
     assert "Missing outputs parameter" in str(err.value)
+
+
+def test_passing_data_to_node_definition():
+
+    graph = Graph()
+
+    @graph.register(inputs=['a', {'b': 2}], outputs=['c'])
+    def f_my_function(a, b):
+        return a + b
+
+    res = graph.calculate(data={'a': 5})
+    assert res == 7
+
+
+def test_wrong_input_type():
+
+    graph = Graph()
+
+    with pytest.raises(PyungoError) as err:
+        @graph.register(inputs=['a', {'b'}], outputs=['c'])
+        def f_my_function(a, b):
+            return a + b
+
+    assert "inputs need to be of type str or dict" in str(err.value)
+
+
+def test_empty_input_dict():
+
+    graph = Graph()
+
+    with pytest.raises(PyungoError) as err:
+        @graph.register(inputs=['a', {}], outputs=['c'])
+        def f_my_function(a, b):
+            return a + b
+
+    assert "dict inputs should have only one key and cannot be empty" in str(err.value)
+
+
+def test_multiple_keys_input_dict():
+
+    graph = Graph()
+
+    with pytest.raises(PyungoError) as err:
+        @graph.register(inputs=['a', {'b': 1, 'c': 2}], outputs=['c'])
+        def f_my_function(a, b):
+            return a + b
+
+    assert "dict inputs should have only one key and cannot be empty" in str(err.value)


### PR DESCRIPTION
Ability to pass predefined inputs:

```python
@graph.register(inputs=['a', {'b': 2}], outputs=['c'])
    def f_my_function(a, b):
        return a + b
```

Those don't need to be passed in the `dag` data.