### PR TITLE
Input output

### DIFF
--- a/pyungo/io.py
+++ b/pyungo/io.py
@@ -1,0 +1,20 @@
+
+
+class _BaseInputOutput:
+    def __init__(self, name, type_=None, unit=None, description=None):
+        self._name = name
+        self._type = type_
+        self._unit = unit
+        self._description = description
+
+    @property
+    def name(self):
+        return self._name
+
+
+class Input(_BaseInputOutput):
+    pass
+
+
+class Output(_BaseInputOutput):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(HERE, 'README.rst')) as f:
 
 setup(
     name='pyungo',
-    version='0.3.0',
+    version='0.4.0',
     description='Function dependencies resolution and execution',
     long_description=README,
     url='https://github.com/cedricleroy/pyungo',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(HERE, 'README.rst')) as f:
 
 setup(
     name='pyungo',
-    version='0.5.1',
+    version='0.6',
     description='Function dependencies resolution and execution',
     long_description=README,
     url='https://github.com/cedricleroy/pyungo',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import pytest
 from pyungo.core import Graph, PyungoError
+from pyungo.io import Input, Output
 
 
 def test_simple():
@@ -263,7 +264,7 @@ def test_wrong_input_type():
         def f_my_function(a, b):
             return a + b
 
-    assert "inputs need to be of type str or dict" in str(err.value)
+    assert "inputs need to be of type str, dict or pyungo.io.Input" in str(err.value)
 
 
 def test_empty_input_dict():
@@ -288,3 +289,27 @@ def test_multiple_keys_input_dict():
             return a + b
 
     assert "dict inputs should have only one key and cannot be empty" in str(err.value)
+
+
+def test_input_output():
+    graph = Graph()
+
+    @graph.register(
+        inputs=[Input('a'), Input('b')],
+        outputs=[Output('c')]
+    )
+    def f_my_function(a, b):
+        return a + b
+
+    @graph.register(inputs=['d', Input('a')], outputs=['e'])
+    def f_my_function3(d, a):
+        return d - a
+
+    @graph.register(inputs=['c'], outputs=[Output('d')])
+    def f_my_function2(c):
+        return c / 10.
+
+    res = graph.calculate(data={'a': 2, 'b': 3})
+
+    assert res == -1.5
+    assert graph.data['e'] == -1.5


### PR DESCRIPTION
Add the possibility to use custom `pyungo` data containers as inputs / outputs:

```python
@graph.register(
        inputs=[Input('a'), Input('b')],
        outputs=[Output('c')]
    )
    def f_my_function(a, b):
        return a + b
```
Those data container need a `name` (mandatory), and have the following arguments: `type_`, `unit` and `description`. Those optional arguments don't lead to extra logic, they are just here for a code display purpose for now.

```python
@graph.register(
        inputs=[Input('a', 'float', 'C', 'Temperature A'), Input('b', 'float', 'C', 'Temperature b')],
        outputs=[Output('c', 'float', 'C', 'Temperature C')]
    )
    def f_my_function(a, b):
        return a + b
```
