### PR TITLE
Fix non-indepodent calcs + contracts feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
           name: install dependencies
           command: |
             pip install multiprocess --user
+            pip install pycontracts --user
       - run:
           name: run tests
           command: |

--- a/pyungo/core.py
+++ b/pyungo/core.py
@@ -79,8 +79,8 @@ class Node:
         return input_names
 
     @property
-    def input_names_without_values(self):
-        input_names = [i.name for i in self._inputs if i.value is None]
+    def input_names_without_constants(self):
+        input_names = [i.name for i in self._inputs if not i.is_constant]
         return input_names
 
     @property
@@ -122,6 +122,8 @@ class Node:
         for input_ in self._inputs:
             if input_.name == input_name:
                 input_.value = value
+                if input_.contract:
+                    input_.check_contract()
                 return
         msg = 'input "{}" does not exist in this node'.format(input_name)
         raise PyungoError(msg)
@@ -154,7 +156,7 @@ class Graph:
     def sim_inputs(self):
         inputs = []
         for node in self._nodes:
-            inputs.extend(node.input_names_without_values)
+            inputs.extend(node.input_names_without_constants)
         return inputs
 
     @property
@@ -251,7 +253,7 @@ class Graph:
             # loading node with inputs
             for item in items:
                 node = self._get_node(item)
-                args = [i_name for i_name in node.input_names_without_values]
+                args = [i_name for i_name in node.input_names_without_constants]
                 for arg in args:
                     node.set_value_to_input(arg, self._data[arg])
             # running nodes

--- a/pyungo/io.py
+++ b/pyungo/io.py
@@ -2,12 +2,20 @@
 
 class Input(object):
 
-    def __init__(self, name, meta=None):
+    def __init__(self, name, meta=None, contract=None):
         self._name = name
         self._meta = meta if meta is not None else {}
         self.value = None
         self.is_arg = False
         self.is_kwarg = False
+        self._contract = None
+        self.is_constant = False
+        if contract:
+            try:
+                from contracts.main import parse_contract_string
+            except ImportError:
+                raise ImportError('pycontracts is needed to use contracts')
+            self._contract = parse_contract_string(contract)
 
     def __repr__(self):
         return '<{} value={} is_arg: {} is_kwarg: {}>'.format(
@@ -18,10 +26,15 @@ class Input(object):
     def name(self):
         return self._name
 
+    @property
+    def contract(self):
+        return self._contract
+
     @classmethod
     def constant(cls, name, value, meta=None):
         me = cls(name, meta)
         me.value = value
+        me.is_constant = True
         return me
 
     @classmethod
@@ -35,3 +48,6 @@ class Input(object):
         me = cls(name, meta)
         me.is_kwarg = True
         return me
+
+    def check_contract(self):
+        self._contract.check(self.value)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,11 @@ def test_simple():
         return c / 10.
 
     res = graph.calculate(data={'a': 2, 'b': 3})
+    assert res == -1.5
+    assert graph.data['e'] == -1.5
 
+    # make sure it is indepodent
+    res = graph.calculate(data={'a': 2, 'b': 3})
     assert res == -1.5
     assert graph.data['e'] == -1.5
 
@@ -305,3 +309,27 @@ def test_Input_type_input():
     res = graph.calculate(data={'a': 2, 'b': 3})
 
     assert res == 5
+
+
+def test_contract():
+
+    from contracts import ContractNotRespected
+
+    graph = Graph()
+
+    @graph.register(
+        inputs=[Input(name='a', contract='int,>0'), 'b'],
+        outputs=['c']
+    )
+    def f_my_function(a, b):
+        return a + b
+
+    res = graph.calculate(data={'a': 2, 'b': 3})
+    assert res == 5
+    res = graph.calculate(data={'a': 2, 'b': 3})
+    assert res == 5
+
+    with pytest.raises(ContractNotRespected) as err:
+        res = graph.calculate(data={'a': -2, 'b': 3})
+
+    assert "Condition -2 > 0 not respected" in str(err.value)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -31,3 +31,4 @@ def test_Input_constant():
     assert inp.value == 2
     assert inp.is_arg is False
     assert inp.is_kwarg is False
+    assert inp.is_constant is True


### PR DESCRIPTION
* Fix calcs that were not indepodent (second calc leaded to crash due to 3ded72fbde39baf101050f8ba21a9ca5d82101f0)
* Implement contracts, e.g.: `inputs=[Input(name='a', contract='int,>0'), 'b']`