### PR TITLE
Input validation with jsonschema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
           command: |
             pip install multiprocess --user
             pip install pycontracts --user
+            pip install jsonschema --user
       - run:
           name: run tests
           command: |

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,8 +111,9 @@
 <li class="toctree-l2"><a class="reference internal" href="source/features.html#parallelism">Parallelism</a></li>
 <li class="toctree-l2"><a class="reference internal" href="source/features.html#args-kwargs-constants">Args, Kwargs, Constants</a></li>
 <li class="toctree-l2"><a class="reference internal" href="source/features.html#input-and-output-objects"><code class="docutils literal notranslate"><span class="pre">Input</span></code> and <code class="docutils literal notranslate"><span class="pre">Output</span></code> objects</a></li>
-<li class="toctree-l2"><a class="reference internal" href="source/features.html#contracts">Contracts</a></li>
+<li class="toctree-l2"><a class="reference internal" href="source/features.html#schema">Schema</a></li>
 <li class="toctree-l2"><a class="reference internal" href="source/features.html#name-mapping">Name mapping</a></li>
+<li class="toctree-l2"><a class="reference internal" href="source/features.html#contracts">Contracts</a></li>
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="source/developer.html">Developer Documentation</a></li>

--- a/docs/source/developer.html
+++ b/docs/source/developer.html
@@ -153,7 +153,7 @@ The nested lists are node ids that can be run in parallel</dd>
 
 <dl class="class">
 <dt id="pyungo.core.Graph">
-<em class="property">class </em><code class="descclassname">pyungo.core.</code><code class="descname">Graph</code><span class="sig-paren">(</span><em>inputs=None</em>, <em>outputs=None</em>, <em>parallel=False</em>, <em>pool_size=2</em><span class="sig-paren">)</span><a class="headerlink" href="#pyungo.core.Graph" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">pyungo.core.</code><code class="descname">Graph</code><span class="sig-paren">(</span><em>inputs=None</em>, <em>outputs=None</em>, <em>parallel=False</em>, <em>pool_size=2</em>, <em>schema=None</em><span class="sig-paren">)</span><a class="headerlink" href="#pyungo.core.Graph" title="Permalink to this definition">¶</a></dt>
 <dd><p>Graph object, collection of related nodes</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
@@ -164,6 +164,7 @@ The nested lists are node ids that can be run in parallel</dd>
 <li><strong>outputs</strong> (<em>list</em>) – List of optional <cite>Output</cite> if defined separately</li>
 <li><strong>parallel</strong> (<em>bool</em>) – Parallelism flag</li>
 <li><strong>pool_size</strong> (<em>int</em>) – Size of the pool in case parallelism is enabled</li>
+<li><strong>schema</strong> (<em>dict</em>) – Optional JSON schema to validate inputs data</li>
 </ul>
 </td>
 </tr>

--- a/docs/source/features.html
+++ b/docs/source/features.html
@@ -61,8 +61,9 @@
 <li class="toctree-l2"><a class="reference internal" href="#parallelism">Parallelism</a></li>
 <li class="toctree-l2"><a class="reference internal" href="#args-kwargs-constants">Args, Kwargs, Constants</a></li>
 <li class="toctree-l2"><a class="reference internal" href="#input-and-output-objects"><code class="docutils literal notranslate"><span class="pre">Input</span></code> and <code class="docutils literal notranslate"><span class="pre">Output</span></code> objects</a></li>
-<li class="toctree-l2"><a class="reference internal" href="#contracts">Contracts</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#schema">Schema</a></li>
 <li class="toctree-l2"><a class="reference internal" href="#name-mapping">Name mapping</a></li>
+<li class="toctree-l2"><a class="reference internal" href="#contracts">Contracts</a></li>
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="developer.html">Developer Documentation</a></li>
@@ -223,20 +224,35 @@ inputs only once (with their special features if any). It is possible to pass a 
 in the nodes can only be strings.</p>
 </div>
 </div>
-<div class="section" id="contracts">
-<h2>Contracts<a class="headerlink" href="#contracts" title="Permalink to this headline">¶</a></h2>
-<p>Sometimes we want to make sure a value meet specific criteria before moving forward.
-<strong>pyungo</strong> uses <a class="reference external" href="https://andreacensi.github.io/contracts/">pycontracts</a> for attaching
-contracts to inputs or outputs.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">pyungo.io</span> <span class="k">import</span> <span class="n">Input</span><span class="p">,</span> <span class="n">Output</span>
+<div class="section" id="schema">
+<h2>Schema<a class="headerlink" href="#schema" title="Permalink to this headline">¶</a></h2>
+<p>Inputs validation is an important step to run a model with confidence. pyungo uses the
+<a class="reference external" href="https://json-schema.org/">JSON Schema specification</a> through a Python library:
+<a class="reference external" href="https://github.com/Julian/jsonschema">jsonschema</a>. The following is now possible:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">schema</span> <span class="o">=</span> <span class="p">{</span>
+    <span class="s2">&quot;type&quot;</span><span class="p">:</span> <span class="s2">&quot;object&quot;</span><span class="p">,</span>
+    <span class="s2">&quot;properties&quot;</span><span class="p">:</span> <span class="p">{</span>
+        <span class="s2">&quot;a&quot;</span><span class="p">:</span> <span class="p">{</span><span class="s2">&quot;type&quot;</span><span class="p">:</span> <span class="s2">&quot;number&quot;</span><span class="p">},</span>
+        <span class="s2">&quot;b&quot;</span><span class="p">:</span> <span class="p">{</span><span class="s2">&quot;type&quot;</span><span class="p">:</span> <span class="s2">&quot;number&quot;</span><span class="p">}</span>
+    <span class="p">}</span>
+<span class="p">}</span>
 
-<span class="n">graph</span><span class="o">.</span><span class="n">add_node</span><span class="p">(</span>
-    <span class="n">my_function</span><span class="p">,</span>
-    <span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">Input</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;a&#39;</span><span class="p">,</span> <span class="n">contract</span><span class="o">=</span><span class="s1">&#39;&gt;0&#39;</span><span class="p">),</span> <span class="n">Input</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;b&#39;</span><span class="p">,</span> <span class="n">contract</span><span class="o">=</span><span class="s1">&#39;float&#39;</span><span class="p">)],</span>
-    <span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">Output</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;g&#39;</span><span class="p">,</span> <span class="n">contract</span><span class="o">=</span><span class="s1">&#39;float&#39;</span><span class="p">)]</span>
+<span class="n">graph</span> <span class="o">=</span> <span class="n">Graph</span><span class="p">(</span><span class="n">schema</span><span class="o">=</span><span class="n">schema</span><span class="p">)</span>
+
+<span class="nd">@graph</span><span class="o">.</span><span class="n">register</span><span class="p">(</span>
+    <span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;a&#39;</span><span class="p">,</span> <span class="s1">&#39;b&#39;</span><span class="p">],</span>
+    <span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;c&#39;</span><span class="p">]</span>
 <span class="p">)</span>
+<span class="k">def</span> <span class="nf">f_my_function</span><span class="p">(</span><span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">):</span>
+    <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
+
+<span class="n">graph</span><span class="o">.</span><span class="n">calculate</span><span class="p">(</span><span class="n">data</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;a&#39;</span><span class="p">:</span> <span class="mi">1</span><span class="p">,</span> <span class="s1">&#39;b&#39;</span><span class="p">:</span> <span class="s1">&#39;2&#39;</span><span class="p">})</span>
 </pre></div>
 </div>
+<p>The calculation is going to fail as <code class="docutils literal notranslate"><span class="pre">b</span></code> is of type string. It is better to catch this problem
+early on before running the model. As we provided a schema saying we explicitely want <code class="docutils literal notranslate"><span class="pre">b</span></code> to
+be of type <code class="docutils literal notranslate"><span class="pre">number</span></code>, the data validation against the schema will fail with the following error:
+<code class="docutils literal notranslate"><span class="pre">'2'</span> <span class="pre">is</span> <span class="pre">not</span> <span class="pre">of</span> <span class="pre">type</span> <span class="pre">'number'</span></code>.</p>
 </div>
 <div class="section" id="name-mapping">
 <h2>Name mapping<a class="headerlink" href="#name-mapping" title="Permalink to this headline">¶</a></h2>
@@ -254,6 +270,21 @@ formulas. pyungo makes things easy providing a mapping feature. Here is an examp
 <span class="n">res</span> <span class="o">=</span> <span class="n">graph</span><span class="o">.</span><span class="n">calculate</span><span class="p">(</span><span class="n">data</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;q&#39;</span><span class="p">:</span> <span class="mi">2</span><span class="p">,</span> <span class="s1">&#39;w&#39;</span><span class="p">:</span> <span class="mi">3</span><span class="p">})</span>
 <span class="k">assert</span> <span class="n">res</span> <span class="o">==</span> <span class="mi">5</span>
 <span class="k">assert</span> <span class="n">graph</span><span class="o">.</span><span class="n">data</span><span class="p">[</span><span class="s1">&#39;e&#39;</span><span class="p">]</span> <span class="o">==</span> <span class="mi">5</span>
+</pre></div>
+</div>
+</div>
+<div class="section" id="contracts">
+<h2>Contracts<a class="headerlink" href="#contracts" title="Permalink to this headline">¶</a></h2>
+<p>Sometimes we want to make sure a value meet specific criteria before moving forward.
+<strong>pyungo</strong> uses <a class="reference external" href="https://andreacensi.github.io/contracts/">pycontracts</a> for attaching
+contracts to inputs or outputs.</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">pyungo.io</span> <span class="k">import</span> <span class="n">Input</span><span class="p">,</span> <span class="n">Output</span>
+
+<span class="n">graph</span><span class="o">.</span><span class="n">add_node</span><span class="p">(</span>
+    <span class="n">my_function</span><span class="p">,</span>
+    <span class="n">inputs</span><span class="o">=</span><span class="p">[</span><span class="n">Input</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;a&#39;</span><span class="p">,</span> <span class="n">contract</span><span class="o">=</span><span class="s1">&#39;&gt;0&#39;</span><span class="p">),</span> <span class="n">Input</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;b&#39;</span><span class="p">,</span> <span class="n">contract</span><span class="o">=</span><span class="s1">&#39;float&#39;</span><span class="p">)],</span>
+    <span class="n">outputs</span><span class="o">=</span><span class="p">[</span><span class="n">Output</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;g&#39;</span><span class="p">,</span> <span class="n">contract</span><span class="o">=</span><span class="s1">&#39;float&#39;</span><span class="p">)]</span>
+<span class="p">)</span>
 </pre></div>
 </div>
 </div>

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -133,22 +133,38 @@ inputs only once (with their special features if any). It is possible to pass a 
    If inputs / outputs are explicitely provided to a graph, inputs / outputs defined
    in the nodes can only be strings.
 
-Contracts
-#########
+Schema
+######
 
-Sometimes we want to make sure a value meet specific criteria before moving forward.
-**pyungo** uses `pycontracts <https://andreacensi.github.io/contracts/>`_ for attaching
-contracts to inputs or outputs.
+Inputs validation is an important step to run a model with confidence. pyungo uses the
+`JSON Schema specification <https://json-schema.org/>`_ through a Python library: 
+`jsonschema <https://github.com/Julian/jsonschema>`_. The following is now possible:
 
 ::
 
-    from pyungo.io import Input, Output
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "number"},
+            "b": {"type": "number"}
+        }
+    }
 
-    graph.add_node(
-        my_function,
-        inputs=[Input(name='a', contract='>0'), Input(name='b', contract='float')],
-        outputs=[Output(name='g', contract='float')]
+    graph = Graph(schema=schema)
+
+    @graph.register(
+        inputs=['a', 'b'],
+        outputs=['c']
     )
+    def f_my_function(a, b):
+        return a + b
+
+    graph.calculate(data={'a': 1, 'b': '2'})
+
+The calculation is going to fail as ``b`` is of type string. It is better to catch this problem
+early on before running the model. As we provided a schema saying we explicitely want ``b`` to
+be of type ``number``, the data validation against the schema will fail with the following error:
+``'2' is not of type 'number'``.
 
 Name mapping
 ############
@@ -170,3 +186,20 @@ formulas. pyungo makes things easy providing a mapping feature. Here is an examp
     res = graph.calculate(data={'q': 2, 'w': 3})
     assert res == 5
     assert graph.data['e'] == 5
+
+Contracts
+#########
+
+Sometimes we want to make sure a value meet specific criteria before moving forward.
+**pyungo** uses `pycontracts <https://andreacensi.github.io/contracts/>`_ for attaching
+contracts to inputs or outputs.
+
+::
+
+    from pyungo.io import Input, Output
+
+    graph.add_node(
+        my_function,
+        inputs=[Input(name='a', contract='>0'), Input(name='b', contract='float')],
+        outputs=[Output(name='g', contract='float')]
+    )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
     extra_require={
         'all': [
             'multiprocess',
-            'pycontracts'
+            'pycontracts',
+            'jsonschema'
         ]
     },
     classifiers=[

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -408,3 +408,34 @@ def test_map():
     res = graph.calculate(data={'q': 2, 'w': 3})
     assert res == 5
     assert graph.data['e'] == 5
+
+
+def test_schema():
+
+    from jsonschema import ValidationError
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "a": {"type": "number"},
+            "b": {"type": "number"}
+        }
+    }
+
+    graph = Graph(schema=schema)
+
+    @graph.register(
+        inputs=['a', 'b'],
+        outputs=['c']
+    )
+    def f_my_function(a, b):
+        return a + b
+
+    with pytest.raises(ValidationError) as err:
+        graph.calculate(data={'a': 1, 'b': '2'})
+
+    msg = "'2' is not of type 'number'"
+    assert msg in str(err.value)
+
+    res = graph.calculate(data={'a': 1, 'b': 2})
+    assert res == 3


### PR DESCRIPTION
Example:

```python
schema = {
    "type": "object",
    "properties": {
        "a": {"type": "number"},
        "b": {"type": "number"}
    }
}

graph = Graph(schema=schema)

@graph.register(
    inputs=['a', 'b'],
    outputs=['c']
)
def f_my_function(a, b):
    return a + b

graph.calculate(data={'a': 1, 'b': '2'})
```

```
>>> '2' is not of type 'number'
```