### PR TITLE
Now the user can decide if using deepcopy on input data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv*/
 .DS_Store
 docs/_build/
 .mypy_cache/
+.idea

--- a/pyungo/core.py
+++ b/pyungo/core.py
@@ -17,7 +17,6 @@ LOGGER.setLevel(logging.INFO)
 
 COPY_TIME_MAX_PERCENTAGE = 0.05
 
-
 def topological_sort(data):
     """ Topological sort algorithm
 
@@ -219,6 +218,7 @@ class Graph:
         parallel (bool): Parallelism flag
         pool_size (int): Size of the pool in case parallelism is enabled
         schema (dict): Optional JSON schema to validate inputs data
+        do_deepcopy (bool): Enables the deep-copying of inputs in order to guarantee immutability
 
     Raises:
         ImportError will raise in case parallelism is chosen and `multiprocess`
@@ -415,13 +415,21 @@ class Graph:
         total_compute_time = t2 - t1
         LOGGER.info('Calculation finished in {}'.format(total_compute_time))
 
-        data_copy_perc = data_copy_time.total_seconds() / total_compute_time.total_seconds()
+        total_compute_time_seconds = total_compute_time.total_seconds()
+
+        if total_compute_time_seconds > 0:
+            data_copy_perc = data_copy_time.total_seconds() / total_compute_time.total_seconds()
+        else:
+            data_copy_perc = 0
 
         if data_copy_perc > COPY_TIME_MAX_PERCENTAGE:
-            LOGGER.warning(
+            msg = (
                 'Data copy time was {} that is {:.1f}% of a total time of {}. '
-                'Consider using do_deepcopy=False during the graph instantiation.'.format(data_copy_time,
-                                                                                          data_copy_perc * 100,
-                                                                                          total_compute_time))
+                'Consider using do_deepcopy=False during the graph instantiation.'
+            )
+
+            LOGGER.warning(
+                msg.format(data_copy_time, data_copy_perc * 100, total_compute_time)
+            )
 
         return res

--- a/pyungo/data.py
+++ b/pyungo/data.py
@@ -1,12 +1,15 @@
 """ class abstracting data passed as inputs and saved as outputs """
 from copy import deepcopy
 
-from pyungo.errors import PyungoError
+from .errors import PyungoError
 
 
 class Data:
-    def __init__(self, inputs):
-        self._inputs = deepcopy(inputs)
+    def __init__(self, inputs, do_deepcopy=True):
+        if do_deepcopy:
+            self._inputs = deepcopy(inputs)
+        else:
+            self._inputs = inputs
         self._outputs = {}
 
     @property

--- a/pyungo/utils.py
+++ b/pyungo/utils.py
@@ -1,7 +1,7 @@
 import ast
 import inspect
 
-from pyungo.errors import PyungoError
+from .errors import PyungoError
 
 
 def get_function_return_names(fct):


### PR DESCRIPTION
I was working on an image processing pipeline on Raspberry Pi using pyungo, I found that the deepcopy operation that happens in the constructor of the Data class took a long time, in the neighborhood of 20ms.

That is due to the fact that input data was a complete frame (a numpy array) that is quite big. Removing the deepcopy operation made me save those 20ms, that is a total performance gain of 14% (my fps is around 8 without deepcopy and around 7 with deepcopy).

I consider this a big improvement. So I added the possibility of disabling the deepcopy behaviour (since it is obviously a bad idea to disable it by default) and a warning that suggests the user to disable the deepcopy if the copy time goes over the 5% of total compute time for the graph.

As a note, on a standard pc the deepcopy operation takes like 0ms, but since on less powerful hardware the difference is so strong I think it is a good idea to implement this little modification.